### PR TITLE
Fix benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 pub fn bench_cat(c: &mut Criterion) {
     let code = fs::read_to_string("examples/cat.bf").unwrap();
-    c.bench_function("cat.bf", |b| {
+    c.bench_function("cat", |b| {
         b.iter(|| {
             let program = compile(black_box(&code)).unwrap();
             let input = b"meow".to_vec();
@@ -15,7 +15,7 @@ pub fn bench_cat(c: &mut Criterion) {
 
 pub fn bench_elvm_hello(c: &mut Criterion) {
     let code = fs::read_to_string("examples/elvm-hello.bf").unwrap();
-    c.bench_function("elvm-hello.bf", |b| {
+    c.bench_function("elvm_hello", |b| {
         b.iter(|| {
             let program = compile(black_box(&code)).unwrap();
             let input = b"".to_vec();


### PR DESCRIPTION
#5 でベンチマークの取得に失敗していたのを修正

ベンチマーク名は `[\w/]+` にマッチしなければならない

https://github.com/rhysd/github-action-benchmark/blob/a1914d7dcbe14d006e4b5f12c7ff303a82a411f1/src/extract.ts#L181